### PR TITLE
Add keyboard shortcuts for AI actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TextBoost AI (Chrome Extension)
 
 Highlight text inside an input, textarea, or contenteditable element. Right-click → **TextBoost AI** → choose:
-- **Better write** (clarify & fix grammar)
+- **Quick rewrite** (clarify & fix grammar)
 - **Summarize**
 - **Write in detail**
 

--- a/background.js
+++ b/background.js
@@ -40,9 +40,9 @@ chrome.runtime.onInstalled.addListener(() => {
         contexts: ["editable"]
     });
     chrome.contextMenus.create({
-        id: "ai-better-write",
+        id: "ai-quick-rewrite",
         parentId: "ai-root",
-        title: "Better write (clarify & fix grammar)",
+        title: "Quick rewrite (clarify & fix grammar)",
         contexts: ["editable"]
     });
     chrome.contextMenus.create({
@@ -59,7 +59,7 @@ chrome.runtime.onInstalled.addListener(() => {
     });
 });
 async function handleAction(action, tabId) {
-    if (!tabId || !["ai-better-write", "ai-summarize", "ai-expand"].includes(action)) return;
+    if (!tabId || !["ai-quick-rewrite", "ai-summarize", "ai-expand"].includes(action)) return;
 
     const [{ result, error }] = await chrome.scripting.executeScript({
         target: { tabId },
@@ -109,14 +109,14 @@ chrome.contextMenus.onClicked.addListener((info, tab) => {
 chrome.commands.onCommand.addListener(async (command) => {
     const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
     if (!tab || !tab.id) return;
-    const action = command === "ai-better-write-alt" ? "ai-better-write" : command;
+    const action = command === "ai-quick-rewrite-alt" ? "ai-quick-rewrite" : command;
     handleAction(action, tab.id);
 });
 
 function buildPrompt(action, text) {
     const base = `You are a rewriting assistant. Output plain text only (no markdown fences or quotes). Do not explain, do not comment, do not roleplay. Only return the rewritten version of the given text. Preserve meaning.`;
 
-    if (action === "ai-better-write") {
+    if (action === "ai-quick-rewrite") {
         return `${base}\n\nTask: Rewrite the text to be clearer, fixing grammar and punctuation while keeping the same tone and meaning. Return only the rewritten text.\n\n----\n${text}\n----`;
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -36,19 +36,19 @@
     }
   ],
   "commands": {
-    "ai-better-write": {
+    "ai-quick-rewrite": {
       "suggested_key": {
-        "default": "Ctrl+Alt+B",
-        "mac": "Command+Option+B"
+        "default": "Ctrl+Alt+Q",
+        "mac": "Command+Option+Q"
       },
-      "description": "Better write (clarify & fix grammar)"
+      "description": "Quick rewrite (clarify & fix grammar)"
     },
-    "ai-better-write-alt": {
+    "ai-quick-rewrite-alt": {
       "suggested_key": {
-        "default": "Alt+B",
-        "mac": "Option+B"
+        "default": "Alt+Q",
+        "mac": "Option+Q"
       },
-      "description": "Better write (Alt+B)"
+      "description": "Quick rewrite (Alt+Q)"
     },
     "ai-summarize": {
       "suggested_key": {

--- a/manifest.json
+++ b/manifest.json
@@ -34,5 +34,35 @@
       ],
       "run_at": "document_idle"
     }
-  ]
+  ],
+  "commands": {
+    "ai-better-write": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+B",
+        "mac": "Command+Option+B"
+      },
+      "description": "Better write (clarify & fix grammar)"
+    },
+    "ai-better-write-alt": {
+      "suggested_key": {
+        "default": "Alt+B",
+        "mac": "Option+B"
+      },
+      "description": "Better write (Alt+B)"
+    },
+    "ai-summarize": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+S",
+        "mac": "Command+Option+S"
+      },
+      "description": "Summarize"
+    },
+    "ai-expand": {
+      "suggested_key": {
+        "default": "Ctrl+Alt+E",
+        "mac": "Command+Option+E"
+      },
+      "description": "Write in detail"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Add manifest `commands` for Better write, Summarize, and Expand actions with Alt-based shortcuts
- Handle keyboard shortcuts in background script and reuse existing logic

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aacd0270708324bc41239146271da5