### PR TITLE
Fix invalid keyboard shortcuts in manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,8 +38,8 @@
   "commands": {
     "ai-quick-rewrite": {
       "suggested_key": {
-        "default": "Ctrl+Alt+Q",
-        "mac": "Command+Option+Q"
+        "default": "Ctrl+Shift+Q",
+        "mac": "Command+Shift+Q"
       },
       "description": "Quick rewrite (clarify & fix grammar)"
     },
@@ -52,15 +52,15 @@
     },
     "ai-summarize": {
       "suggested_key": {
-        "default": "Ctrl+Alt+S",
-        "mac": "Command+Option+S"
+        "default": "Ctrl+Shift+S",
+        "mac": "Command+Shift+S"
       },
       "description": "Summarize"
     },
     "ai-expand": {
       "suggested_key": {
-        "default": "Ctrl+Alt+E",
-        "mac": "Command+Option+E"
+        "default": "Ctrl+Shift+E",
+        "mac": "Command+Shift+E"
       },
       "description": "Write in detail"
     }


### PR DESCRIPTION
## Summary
- Replace Ctrl+Alt shortcuts with Ctrl+Shift to satisfy Chrome extension requirements

## Testing
- `python -m json.tool manifest.json`

------
https://chatgpt.com/codex/tasks/task_e_68aad0c8494c83248289017f96a66d96