### PR TITLE
Add logo to options page

### DIFF
--- a/options.html
+++ b/options.html
@@ -62,10 +62,11 @@
             margin-bottom: 18px;
         }
         .logo {
-            width: 36px; height: 36px;
+            width: 36px;
+            height: 36px;
             border-radius: 10px;
-            background: linear-gradient(145deg, var(--brand), var(--brand-2));
             box-shadow: 0 12px 30px rgba(95,70,232,0.25), inset 0 0 0 1px rgba(255,255,255,0.06);
+            display: block;
         }
         h1 {
             font-size: 20px;
@@ -252,7 +253,7 @@
 <body>
     <div class="wrap">
         <div class="header">
-            <div class="logo" aria-hidden="true"></div>
+            <img class="logo" src="/icon" alt="TextBoost AI logo" />
             <div>
                 <h1>TextBoost AI Settings</h1>
                 <p class="sub">Configure your provider, models, and generation behavior.</p>


### PR DESCRIPTION
## Summary
- Show extension logo on settings page header using `/icon`.
- Simplify logo styles and remove gradient placeholder.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaea4269ec8324b88477c8c106d21c